### PR TITLE
Include file extension when grep-ing SHA256SUMS

### DIFF
--- a/install-hashicorp-tool.sh
+++ b/install-hashicorp-tool.sh
@@ -54,7 +54,7 @@ echo "--> Downloading ${NAME} v${VERSION} (${OS}/${ARCH})"
 curl -sfSO "${DOWNLOAD_ZIP}"
 
 echo "--> Validating SHA256SUM"
-grep "${NAME}_${VERSION}_${OS}_${ARCH}" "${NAME}_${VERSION}_SHA256SUMS" > "SHA256SUMS"
+grep "${NAME}_${VERSION}_${OS}_${ARCH}.zip" "${NAME}_${VERSION}_SHA256SUMS" > "SHA256SUMS"
 sha256sum -c "SHA256SUMS"
 
 echo "--> Unpacking and installing"


### PR DESCRIPTION
When installing envconsul there are multiple extensions for the same OS
and architecture, `.zip` & `.tgz`.

As we only download the `.zip` version, the script cannot validate the
`.tgz`

This fixes the grep to only search for the downloaded artifact.