### PR TITLE
Remove volume directive

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,6 @@ RUN chmod +x /install-hashicorp-tool
 
 # Where the software will be
 RUN mkdir -p /software
-VOLUME /software
 
 # Setup the entrypoint
 ENTRYPOINT ["/install-hashicorp-tool"]


### PR DESCRIPTION
💁 Declaring a volume means that any changes to data within the volume after it is declared will be discarded ([source](https://docs.docker.com/engine/reference/builder/#notes-about-specifying-volumes)). This makes it unusable in a multi-stage build.

Some output from the "Multi-Stage Builder" example from the project `README.md` which demonstrates this issue follows:

    Step 1/5 : FROM sethvargo/hashicorp-installer AS installer
     ---> 08916ea910a8
    Step 2/5 : RUN /install-hashicorp-tool "terraform" "0.11.7"
     ---> Using cache
     ---> 24e5388016d7
    Step 3/5 : FROM alpine:latest
     ---> 11cd0b38bc3c
    Step 4/5 : COPY --from=installer /software/terraform /terraform
    COPY failed: stat /var/lib/docker/overlay2/aab476857fca5bcdea60ab77374775913d9c536a326eecbdef7aee08e5e2d304/merged/software/terraform: no such file or directory