### PR TITLE
Remove Volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,6 @@ RUN chmod +x /install-hashicorp-tool
 
 # Where the software will be
 RUN mkdir -p /software
-VOLUME /software
 
 # Setup the entrypoint
 ENTRYPOINT ["/install-hashicorp-tool"]


### PR DESCRIPTION
👋  I was trying to use this in a multi-stage docker build and was unable to copy the binary across. This seems to be because of the `VOLUME` in the Dockerfile.

Repo Case: 

`Dockerfile`
```Dockerfile
FROM sethvargo/hashicorp-installer
RUN /install-hashicorp-tool consul 1.0.0 && ls -al /software
RUN ls -al /software
```

`docker build --no-cache .`
```
--> Removing temporary files
--> Done!
total 41852
drwxr-xr-x    2 root     root          4096 Aug 24 13:37 .
drwxr-xr-x    1 root     root          4096 Aug 24 13:37 ..
-rwxr-xr-x    1 root     root      42845786 Oct 16  2017 consul
Removing intermediate container b932614530b0
 ---> c41e6a34608a
Step 3/3 : RUN ls -al /software
 ---> Running in dfb34f69ea51
total 8
drwxr-xr-x    2 root     root          4096 Aug 21 17:10 .
drwxr-xr-x    1 root     root          4096 Aug 24 13:37 ..
Removing intermediate container dfb34f69ea51
 ---> 82781163c1ea
Successfully built 82781163c1ea
```